### PR TITLE
Bump dependencies to latest compatible versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ args==0.1.0
 clint==0.5.1
 crcmod==1.7
 ffmpeg-python==0.2.0
-future==0.18.3
-mutagen==1.46.0
-PyYAML==6.0.1
+future==1.0.0
+mutagen==1.47.0
+PyYAML==6.0.3
 r128gain==1.0.7
-tqdm==4.31.1
+tqdm==4.67.3


### PR DESCRIPTION
- future 0.18.3 → 1.0.0
- mutagen 1.46.0 → 1.47.0
- PyYAML 6.0.1 → 6.0.3
- tqdm 4.31.1 → 4.67.3

Skipped: args, clint (no newer releases); crcmod (no newer releases); ffmpeg-python (r128gain requires ~=0.2, no 0.2.x releases beyond 0.2.0); r128gain (already at latest 1.0.7).